### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 .idea
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
-dist: trusty
-sudo: true
 php:
-  - '7.0'
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
   - nightly
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5 || ^7.0",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
@@ -23,7 +23,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "DivineOmega\\Distance\\Tests\\": "tests/"
+            "DivineOmega\\Distance\\Tests\\": "tests/Unit/"
         }
     }
 }


### PR DESCRIPTION
# Changed log
- Add `*.cache` file on `.gitignore` file to avoid Git version control.
- Removing `sudo` setting because the command used  on Travis CI build doesn't require root user permission.
- The executing `xenial` dist by default on Travis CI build and it's available on `php-7.x` versions.
Removing `dist: trusty` setting.
- Add PHPUnit `^7.0 || ^8.0` versions to support different PHP versions.
- Add `php-7.4` version test on Travis CI build.